### PR TITLE
fix(UX-1540): Fix input chip avatar image

### DIFF
--- a/src/stories/components/Chips/input-chip.stories.ts
+++ b/src/stories/components/Chips/input-chip.stories.ts
@@ -24,7 +24,5 @@ export default meta;
 
 export const InputChip: StoryObj<ZetaInputChip> = {
   render: args =>
-    html`<zeta-input-chip ?rounded=${args.rounded} ?disabled=${args.disabled}
-      ><zeta-avatar size="xxxs"><img src="https://tinyurl.com/yn89fmc4"></img></zeta-avatar> ${args.slot}</zeta-input-chip
-    >`
+    html`<zeta-input-chip ?rounded=${args.rounded} ?disabled=${args.disabled}><zeta-avatar size="xxxs">WW</zeta-avatar>${args.slot}</zeta-input-chip>`
 };


### PR DESCRIPTION
Changed from using an image to just plain text to avoid using free hosting sites which could lead to broken links.