### PR TITLE
feat(UX-1542)!: Make icon optional for text dropdown menu items

### DIFF
--- a/src/components/dropdown/dropdown-menu/dropdown-menu-button.styles.js
+++ b/src/components/dropdown/dropdown-menu/dropdown-menu-button.styles.js
@@ -5,6 +5,10 @@ export default css`
     width: fit-content;
   }
 
+  .with-icon {
+    padding-right: var(--spacing-small);
+  }
+
   .droppable-item {
     height: var(--spacing-6xl);
     padding-left: var(--spacing-medium);

--- a/src/components/dropdown/dropdown-menu/dropdown-menu-button.ts
+++ b/src/components/dropdown/dropdown-menu/dropdown-menu-button.ts
@@ -40,7 +40,7 @@ export class ZetaDropdownMenuButton extends FormField(Contourable(Flavored(Size(
   @property({ type: Array }) items: Array<ZetaDropdownItem> = [
     {
       label: "Auto Item",
-      icon: "star",
+      icon: undefined,
       checked: false
     }
   ];
@@ -182,8 +182,8 @@ export class ZetaDropdownMenuButton extends FormField(Contourable(Flavored(Size(
             }
           }}
           ?rounded=${this.rounded}
-          ><zeta-icon slot="icon" ?rounded=${this.rounded}>${item.icon}</zeta-icon>${item.label}</zeta-dropdown-menu-item
-        >`;
+          >${item.icon ? html`<zeta-icon class="with-icon" slot="icon" ?rounded=${this.rounded}>${item.icon}</zeta-icon>` : ""} ${item.label}
+        </zeta-dropdown-menu-item>`;
       });
     }
   }

--- a/src/components/dropdown/menu-item/dropdown-menu-item.styles.js
+++ b/src/components/dropdown/menu-item/dropdown-menu-item.styles.js
@@ -2,6 +2,8 @@ import { css } from "lit";
 export default css`
   .header {
     display: flex;
+    align-items: center;
+    justify-content: center;
     flex: 1;
   }
 
@@ -14,7 +16,6 @@ export default css`
     padding: var(--spacing-small) var(--spacing-medium);
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
     user-select: none;
     font: var(--body-medium);
   }


### PR DESCRIPTION
Makes icon default set as undefined.

When icon is undefined, no icon is shown.

When an icon name is explicitly set, an icon will be shown, as long as the icon name is in zeta-icons.