### PR TITLE
chore(NO-TICKET): Add part to icon container in in-page-banner

### DIFF
--- a/src/components/in-page-banner/in-page-banner.ts
+++ b/src/components/in-page-banner/in-page-banner.ts
@@ -17,6 +17,7 @@ import type { ZetaIconName } from "@zebra-fed/zeta-icons";
  * @part header - The header section containing the title.
  * @part body - The body section containing the main content.
  * @part footer - The footer section containing action buttons.
+ * @part icon - The container containing the status icon.
  *
  * @event {CustomEvent<ZetaCloseEventDetail>} close - Fired when the close icon is clicked.
  *
@@ -24,7 +25,6 @@ import type { ZetaIconName } from "@zebra-fed/zeta-icons";
  * @cssproperty --banner-background-color - The background color of the banner.
  * @cssproperty --banner-foreground-color - The foreground color of the banner.
  * @cssproperty --banner-icon-color - The icon color of the banner.
- *
  *
  * @figma https://www.figma.com/file/JesXQFLaPJLc1BdBM4sisI/%F0%9F%A6%93-ZDS---Components?node-id=21156-27071
  * @storybook https://design.zebra.com/web/storybook/?path=/docs/components-in-page-banner--docs

--- a/src/components/in-page-banner/in-page-banner.ts
+++ b/src/components/in-page-banner/in-page-banner.ts
@@ -79,7 +79,7 @@ export class ZetaInPageBanner extends Contourable(LitElement) {
   protected render() {
     return html`
       <div class="container">
-        ${this.showIcon ? html` <div class="leading"><zeta-icon .rounded=${this.rounded}>${this.getIcon()}</zeta-icon></div>` : nothing}
+        ${this.showIcon ? html` <div class="leading" part="icon"><zeta-icon .rounded=${this.rounded}>${this.getIcon()}</zeta-icon></div>` : nothing}
         <div class="center">
           <div part="header">${this.title ? html`<div class="title">${this.title}</div>` : nothing}</div>
           <div part="body">

--- a/src/test/in-page-banner/in-page-banner.test.ts
+++ b/src/test/in-page-banner/in-page-banner.test.ts
@@ -111,7 +111,7 @@ describe("zeta-in-page-banner", () => {
     it("has a part on the icon container", async () => {
       const iconContainer = subject.shadowRoot?.querySelector(".leading");
       expect(iconContainer).to.not.be.null;
-      expect(iconContainer?.getAttribute("part")).to.equal("icon");
+      await expect(iconContainer?.getAttribute("part")).to.equal("icon");
     });
   });
 

--- a/src/test/in-page-banner/in-page-banner.test.ts
+++ b/src/test/in-page-banner/in-page-banner.test.ts
@@ -108,10 +108,9 @@ describe("zeta-in-page-banner", () => {
       }
     });
 
-    it("has a part on the icon container", async () => {
-      const iconContainer = subject.shadowRoot?.querySelector(".leading");
+    it("has a part on the icon container", () => {
+      const iconContainer = subject.shadowRoot?.querySelector('[part~="icon"]');
       expect(iconContainer).to.not.be.null;
-      await expect(iconContainer?.getAttribute("part")).to.equal("icon");
     });
   });
 

--- a/src/test/in-page-banner/in-page-banner.test.ts
+++ b/src/test/in-page-banner/in-page-banner.test.ts
@@ -107,6 +107,12 @@ describe("zeta-in-page-banner", () => {
         await expect(icon?.textContent?.trim()).to.equal(expectedIcon);
       }
     });
+
+    it("has a part on the icon container", async () => {
+      const iconContainer = subject.shadowRoot?.querySelector(".leading");
+      expect(iconContainer).to.not.be.null;
+      expect(iconContainer?.getAttribute("part")).to.equal("icon");
+    });
   });
 
   // describe("Dimensions", () => {});


### PR DESCRIPTION
Adds a part to the icon container to allow customisability.