### PR TITLE
feat(UX-1578): Add clear button to text input component

### DIFF
--- a/src/components/text-input/text-input.styles.js
+++ b/src/components/text-input/text-input.styles.js
@@ -8,7 +8,19 @@ export default css`
   }
 
   .cancel-icon {
-    --icon-color: var(--main-default);
+    cursor: pointer;
+
+    &.cancel-icon-textarea {
+      align-self: flex-start;
+    }
+
+    &:hover {
+      --icon-color: var(--border-default);
+    }
+
+    &:active {
+      --icon-color: var(--main-default);
+    }
   }
 
   .hint-text {

--- a/src/components/text-input/text-input.styles.js
+++ b/src/components/text-input/text-input.styles.js
@@ -21,6 +21,10 @@ export default css`
     &:active {
       --icon-color: var(--main-default);
     }
+
+    &:focus-visible {
+      outline: var(--border-size-medium) solid var(--border-primary);
+    }
   }
 
   .hint-text {

--- a/src/components/text-input/text-input.styles.js
+++ b/src/components/text-input/text-input.styles.js
@@ -9,17 +9,18 @@ export default css`
 
   .cancel-icon {
     cursor: pointer;
+    transition: all 0.1s ease-in-out;
 
     &.cancel-icon-textarea {
       align-self: flex-start;
     }
 
     &:hover {
-      --icon-color: var(--border-default);
+      --icon-color: var(--main-default);
     }
 
     &:active {
-      --icon-color: var(--main-default);
+      --icon-color: var(--state-inverse-selected);
     }
 
     &:focus-visible {

--- a/src/components/text-input/text-input.styles.js
+++ b/src/components/text-input/text-input.styles.js
@@ -7,6 +7,10 @@ export default css`
     height: fit-content;
   }
 
+  .cancel-icon {
+    --icon-color: var(--main-default);
+  }
+
   .hint-text {
     --icon-size: 16px;
   }

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -62,7 +62,7 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
   /**
    * Displays a button to clear the text field when true.
    */
-  @property({ type: Boolean, reflect: true }) showClearButton = false;
+  @property({ type: Boolean }) showClearButton = false;
 
   /**
    * Label shown above text field.
@@ -120,14 +120,14 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
   increment() {
     if (this.type === "integer" && Number(this.value) !== this.max) {
       this.value = ((parseFloat(this.value) || 0) + 1).toString();
-      this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      this.dispatchEvent(new Event("change"));
     }
   }
 
   decrement() {
     if (this.type === "integer" && Number(this.value) !== this.min) {
       this.value = ((parseFloat(this.value) || 0) - 1).toString();
-      this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      this.dispatchEvent(new Event("change"));
     }
   }
 
@@ -193,14 +193,30 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
     `;
   }
 
+  private clearValue() {
+    this.value = "";
+    this.dispatchEvent(new InputEvent("input"));
+    this.dispatchEvent(new Event("change"));
+  }
+
+  private handleClearKeyDown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this.clearValue();
+    }
+  }
+
   private renderCloseIcon() {
     return this.showClearButton && this.value
       ? html`<zeta-icon
-          class="cancel-icon"
+          class="cancel-icon right ${this.type === "textarea" ? "cancel-icon-textarea" : ""}"
           @click=${() => {
-            this.value = "";
-            this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+            this.clearValue();
           }}
+          @keydown=${this.handleClearKeyDown}
+          tabindex="0"
+          role="button"
+          aria-label="Clear input"
           >cancel</zeta-icon
         >`
       : nothing;

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -60,6 +60,11 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
   @property({ type: Number }) rows?: number;
 
   /**
+   * Displays a button to clear the text field when true.
+   */
+  @property({ type: Boolean, reflect: true }) showClearButton = false;
+
+  /**
    * Label shown above text field.
    *
    */
@@ -115,14 +120,14 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
   increment() {
     if (this.type === "integer" && Number(this.value) !== this.max) {
       this.value = ((parseFloat(this.value) || 0) + 1).toString();
-      this.dispatchEvent(new Event("change"));
+      this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
     }
   }
 
   decrement() {
     if (this.type === "integer" && Number(this.value) !== this.min) {
       this.value = ((parseFloat(this.value) || 0) - 1).toString();
-      this.dispatchEvent(new Event("change"));
+      this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
     }
   }
 
@@ -176,16 +181,29 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
       "text-area": this.type === "textarea"
     });
     return html`
-      <div class=${containerClass}>${this.renderLeftIcon()} ${this.renderPrefix()} ${super.render()} ${this.renderRightIcon()} ${this.renderSuffix()}</div>
-      ${
-        this.error || this.hintText
-          ? html`<div class="hint-text">
-              <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
-              <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
-            </div> `
-          : nothing
-      }
+      <div class=${containerClass}>
+        ${this.renderLeftIcon()} ${this.renderPrefix()} ${super.render()} ${this.renderRightIcon()} ${this.renderSuffix()} ${this.renderCloseIcon()}
+      </div>
+      ${this.error || this.hintText
+        ? html`<div class="hint-text">
+            <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
+            <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
+          </div> `
+        : nothing}
     `;
+  }
+
+  private renderCloseIcon() {
+    return this.showClearButton && this.value
+      ? html`<zeta-icon
+          class="cancel-icon"
+          @click=${() => {
+            this.value = "";
+            this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+          }}
+          >cancel</zeta-icon
+        >`
+      : nothing;
   }
 
   private renderLeftIcon() {

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -61,6 +61,10 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
 
   /**
    * Displays a button to clear the text field when true.
+   * This will always display in the right most position and will push any trailing icon or suffix to the left.
+   * It will apply to all text field types and will push any type specific interactions to the left as well.
+   * For type `textarea`, the clear button will be displayed in the top right corner of the text area.
+   * The clear button will not be displayed if the text field is disabled or read-only.
    */
   @property({ type: Boolean }) showClearButton = false;
 
@@ -184,21 +188,21 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
       <div class=${containerClass}>
         ${this.renderLeftIcon()} ${this.renderPrefix()} ${super.render()} ${this.renderRightIcon()} ${this.renderSuffix()} ${this.renderCloseIcon()}
       </div>
-      ${
-        this.error || this.hintText
-          ? html`<div class="hint-text">
-              <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
-              <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
-            </div> `
-          : nothing
-      }
+      ${this.error || this.hintText
+        ? html`<div class="hint-text">
+            <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
+            <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
+          </div> `
+        : nothing}
     `;
   }
 
   private clearValue() {
+    if (this.disabled || this.readOnly) return;
     this.value = "";
-    this.dispatchEvent(new InputEvent("input"));
-    this.dispatchEvent(new Event("change"));
+    this.internals.setFormValue(this.value);
+    this._valueOnLastFocus = this.value;
+    this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
   }
 
   private handleClearKeyDown(e: KeyboardEvent) {
@@ -209,7 +213,7 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
   }
 
   private renderCloseIcon() {
-    return this.showClearButton && this.value
+    return this.showClearButton && !this.disabled && !this.readOnly && (this.value ?? "") !== ""
       ? html`<zeta-icon
           class="cancel-icon right ${this.type === "textarea" ? "cancel-icon-textarea" : ""}"
           @click=${() => {

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -188,12 +188,14 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
       <div class=${containerClass}>
         ${this.renderLeftIcon()} ${this.renderPrefix()} ${super.render()} ${this.renderRightIcon()} ${this.renderSuffix()} ${this.renderCloseIcon()}
       </div>
-      ${this.error || this.hintText
-        ? html`<div class="hint-text">
-            <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
-            <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
-          </div> `
-        : nothing}
+      ${
+        this.error || this.hintText
+          ? html`<div class="hint-text">
+              <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
+              <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
+            </div> `
+          : nothing
+      }
     `;
   }
 

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -184,12 +184,14 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
       <div class=${containerClass}>
         ${this.renderLeftIcon()} ${this.renderPrefix()} ${super.render()} ${this.renderRightIcon()} ${this.renderSuffix()} ${this.renderCloseIcon()}
       </div>
-      ${this.error || this.hintText
-        ? html`<div class="hint-text">
-            <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
-            <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
-          </div> `
-        : nothing}
+      ${
+        this.error || this.hintText
+          ? html`<div class="hint-text">
+              <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
+              <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
+            </div> `
+          : nothing
+      }
     `;
   }
 

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -184,14 +184,12 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
       <div class=${containerClass}>
         ${this.renderLeftIcon()} ${this.renderPrefix()} ${super.render()} ${this.renderRightIcon()} ${this.renderSuffix()} ${this.renderCloseIcon()}
       </div>
-      ${
-        this.error || this.hintText
-          ? html`<div class="hint-text">
-              <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
-              <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
-            </div> `
-          : nothing
-      }
+      ${this.error || this.hintText
+        ? html`<div class="hint-text">
+            <zeta-icon .rounded=${this.rounded}>${this.error ? "error" : "info"}</zeta-icon>
+            <span id="hint-text">${this.error ? this.errorText : this.hintText}</span>
+          </div> `
+        : nothing}
     `;
   }
 
@@ -215,7 +213,9 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
           @click=${() => {
             this.clearValue();
           }}
-          @keydown=${this.handleClearKeyDown}
+          @keydown=${(e: KeyboardEvent) => {
+            this.handleClearKeyDown(e);
+          }}
           tabindex="0"
           role="button"
           aria-label="Clear input"

--- a/src/mixins/form-field.ts
+++ b/src/mixins/form-field.ts
@@ -51,6 +51,7 @@ declare abstract class FormFieldInterface {
   placeholder: string;
   min: number;
   max: number;
+  readOnly?: boolean;
   abstract handleChange(event: Event): void;
   handleInput(event: Event): void;
   handleFocus(event: FocusEvent): void;

--- a/src/stories/components/text-input.stories.ts
+++ b/src/stories/components/text-input.stories.ts
@@ -68,7 +68,7 @@ export const TextInput: StoryObj<InputStory> = {
   name: "Default text input",
   render: ({ oninput, onchange, onblur, onfocus, ...args }) =>
     html`<div style="width: 200px; height: 400px;">
-      <zeta-text-input min="50" max="200" @change=${onchange} @input=${oninput} @blur=${onblur} @focus=${onfocus} ${spread(args)}> </zeta-text-input>
+      <zeta-text-input min="50" max="200" @change=${onchange} @input=${oninput} @blur=${onblur} @focus=${onfocus} ${spread(args)}></zeta-text-input>
     </div>`
 };
 

--- a/src/stories/components/text-input.stories.ts
+++ b/src/stories/components/text-input.stories.ts
@@ -23,6 +23,7 @@ const meta: Meta<InputStory> = {
     required: false,
     prefix: "",
     suffix: "",
+    showClearButton: false,
     onchange: fn(),
     oninput: fn(),
     onfocus: fn(),
@@ -67,8 +68,7 @@ export const TextInput: StoryObj<InputStory> = {
   name: "Default text input",
   render: ({ oninput, onchange, onblur, onfocus, ...args }) =>
     html`<div style="width: 200px; height: 400px;">
-      <zeta-text-input type="integer" min="50" max="200" @change=${onchange} @input=${oninput} @blur=${onblur} @focus=${onfocus} ${spread(args)}>
-      </zeta-text-input>
+      <zeta-text-input min="50" max="200" @change=${onchange} @input=${oninput} @blur=${onblur} @focus=${onfocus} ${spread(args)}> </zeta-text-input>
     </div>`
 };
 

--- a/src/test/text-input/setup.ts
+++ b/src/test/text-input/setup.ts
@@ -21,6 +21,7 @@ interface Props {
   min?: number;
   max?: number;
   rows?: number;
+  showClearButton?: boolean;
 }
 
 export async function setup({
@@ -39,7 +40,8 @@ export async function setup({
   value = undefined,
   min = undefined,
   max = undefined,
-  rows = undefined
+  rows = undefined,
+  showClearButton = false
 }: Props) {
   return await fixture<ZetaTextInput>(
     html`<zeta-text-input
@@ -59,6 +61,7 @@ export async function setup({
       min=${ifDefined(min)}
       max=${ifDefined(max)}
       rows=${ifDefined(rows)}
+      ?showClearButton=${showClearButton}
     ></zeta-text-input>`
   );
 }

--- a/src/test/text-input/text-input.test.ts
+++ b/src/test/text-input/text-input.test.ts
@@ -115,6 +115,18 @@ describe("zeta-text-input", () => {
       const el = await setup({ type: "date" });
       assert.equal(el.shadowRoot?.querySelector("zeta-icon")?.textContent?.trim(), "calendar_3_day");
     });
+
+    it("should show clear button when showClearButton is true and value is not empty", async () => {
+      const el = await setup({ showClearButton: true, value: "Some text" });
+      const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
+      assert.exists(clearButton, "Clear button should exist");
+    });
+
+    it("should not show clear button when showClearButton is false", async () => {
+      const el = await setup({ showClearButton: false, value: "Some text" });
+      const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
+      assert.notExists(clearButton, "Clear button should not exist");
+    });
   });
 
   // describe("Dimensions", () => {});
@@ -351,6 +363,15 @@ describe("zeta-text-input", () => {
       await MouseActions.clickOutside(el);
 
       await expect(el.value).to.equal("50");
+    });
+
+    it("should clear the text input when the clear button is clicked", async () => {
+      const el = await setup({ showClearButton: true, value: "Some text" });
+      const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
+      assert.exists(clearButton, "Clear button should exist");
+
+      clearButton?.dispatchEvent(new Event("click", { bubbles: true, composed: true }));
+      await expect(el.value).to.equal("");
     });
   });
 

--- a/src/test/text-input/text-input.test.ts
+++ b/src/test/text-input/text-input.test.ts
@@ -375,12 +375,9 @@ describe("zeta-text-input", () => {
       const el = await setup({ showClearButton: true, value: "Some text" });
       const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
       assert.exists(clearButton, "Clear button should exist");
-
-      const inputListener = oneEvent(el, "input");
       const changeListener = oneEvent(el, "change");
 
       clearButton?.dispatchEvent(new Event("click", { bubbles: true, composed: true }));
-      await inputListener;
       await changeListener;
       await expect(el.value).to.equal("");
     });

--- a/src/test/text-input/text-input.test.ts
+++ b/src/test/text-input/text-input.test.ts
@@ -127,6 +127,12 @@ describe("zeta-text-input", () => {
       const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
       assert.notExists(clearButton, "Clear button should not exist");
     });
+
+    it("should not show clear button when showClearButton is true but value is empty", async () => {
+      const el = await setup({ showClearButton: true, value: "" });
+      const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
+      assert.notExists(clearButton, "Clear button should not exist");
+    });
   });
 
   // describe("Dimensions", () => {});
@@ -370,7 +376,12 @@ describe("zeta-text-input", () => {
       const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
       assert.exists(clearButton, "Clear button should exist");
 
+      const inputListener = oneEvent(el, "input");
+      const changeListener = oneEvent(el, "change");
+
       clearButton?.dispatchEvent(new Event("click", { bubbles: true, composed: true }));
+      await inputListener;
+      await changeListener;
       await expect(el.value).to.equal("");
     });
   });


### PR DESCRIPTION
Adds clear button to text input when showClearButton is true and there is text currently in the input.