### PR TITLE
fix: Min / Max types on text input

### DIFF
--- a/src/components/stepper-input/stepper-input.ts
+++ b/src/components/stepper-input/stepper-input.ts
@@ -108,12 +108,14 @@ export class ZetaStepperInput extends FormField(Contourable(LitElement)) {
 
   private validateValue(value: string): string {
     const valueToNumber = Number(value);
+    const max = this.max !== undefined ? Number(this.max) : undefined;
+    const min = this.min !== undefined ? Number(this.min) : undefined;
     if (isNaN(valueToNumber) || valueToNumber === undefined) {
       value = "0";
-    } else if (this.max && valueToNumber >= this.max) {
-      value = this.max.toString();
-    } else if (this.min !== undefined && valueToNumber <= this.min) {
-      value = this.min.toString();
+    } else if (max !== undefined && isFinite(max) && valueToNumber >= max) {
+      value = String(max);
+    } else if (min !== undefined && isFinite(min) && valueToNumber <= min) {
+      value = String(min);
     } else {
       value = valueToNumber.toString();
     }
@@ -135,7 +137,7 @@ export class ZetaStepperInput extends FormField(Contourable(LitElement)) {
       <div>
         <div class="container">
           <zeta-icon-button
-            .disabled=${this.disabled || (this.min !== undefined && Number(this.value) <= this.min)}
+            .disabled=${this.disabled || (this.min !== undefined && isFinite(Number(this.min)) && Number(this.value) <= Number(this.min))}
             shape=${this.rounded ? "rounded" : "sharp"}
             size=${this.size}
             flavor="outline-subtle"
@@ -147,7 +149,7 @@ export class ZetaStepperInput extends FormField(Contourable(LitElement)) {
           </zeta-icon-button>
           <div class="input-container contourable-target">${super.render()}</div>
           <zeta-icon-button
-            .disabled=${this.disabled || (this.max !== undefined && Number(this.value) >= this.max)}
+            .disabled=${this.disabled || (this.max !== undefined && isFinite(Number(this.max)) && Number(this.value) >= Number(this.max))}
             shape=${this.rounded ? "rounded" : "sharp"}
             size=${this.size}
             @blur=${(e: FocusEvent) => this.handleBlur(e)}

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -122,14 +122,14 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
 
   /* INTEGER MODE */
   increment() {
-    if (this.type === "integer" && Number(this.value) !== this.max) {
+    if (this.type === "integer" && (this.max === undefined || Number(this.value) < Number(this.max))) {
       this.value = ((parseFloat(this.value) || 0) + 1).toString();
       this.dispatchEvent(new Event("change"));
     }
   }
 
   decrement() {
-    if (this.type === "integer" && Number(this.value) !== this.min) {
+    if (this.type === "integer" && (this.min === undefined || Number(this.value) > Number(this.min))) {
       this.value = ((parseFloat(this.value) || 0) - 1).toString();
       this.dispatchEvent(new Event("change"));
     }

--- a/src/components/text-input/text-input.ts
+++ b/src/components/text-input/text-input.ts
@@ -122,14 +122,14 @@ export class ZetaTextInput extends FormField(Size(Contourable(Interactive(LitEle
 
   /* INTEGER MODE */
   increment() {
-    if (this.type === "integer" && (this.max === undefined || Number(this.value) < Number(this.max))) {
+    if (this.type === "integer" && (this.max === undefined || !isFinite(Number(this.max)) || Number(this.value) < Number(this.max))) {
       this.value = ((parseFloat(this.value) || 0) + 1).toString();
       this.dispatchEvent(new Event("change"));
     }
   }
 
   decrement() {
-    if (this.type === "integer" && (this.min === undefined || Number(this.value) > Number(this.min))) {
+    if (this.type === "integer" && (this.min === undefined || !isFinite(Number(this.min)) || Number(this.value) > Number(this.min))) {
       this.value = ((parseFloat(this.value) || 0) - 1).toString();
       this.dispatchEvent(new Event("change"));
     }

--- a/src/mixins/form-field.ts
+++ b/src/mixins/form-field.ts
@@ -308,17 +308,27 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
       }
     }
 
+    /**
+     * Formats a `min`/`max` value for use as an HTML attribute.
+     *
+     * - `undefined` → omitted (no attribute set).
+     * - `string` → passed through as-is (e.g. `"2024-01-01"` for date inputs).
+     * - `number` on `date`/`time` inputs → interpreted as a UTC epoch-millisecond timestamp
+     *   and formatted to the string the browser expects (`YYYY-MM-DD`, `HH:MM`). **Note:**
+     *   formatting is always UTC — pass a string if you need a locale-specific boundary
+     *   (e.g. `new Date(ts).toLocaleDateString(...)`).
+     * - `number` on any other input type → stringified directly (e.g. `"100"` for `number`).
+     */
     private _formatMinMax(value: string | number | undefined): string | undefined {
       if (value === undefined) return undefined;
       if (typeof value === "string") return value;
-      // Only interpret numeric values as epoch-ms timestamps for date-like types
-      if (this.type !== "date" && this.type !== "time" && this.type !== "month") return String(value);
+      // Only interpret numeric values as epoch-ms timestamps for date/time types
+      if (this.type !== "date" && this.type !== "time") return String(value);
       const date = new Date(value);
       if (isNaN(date.getTime())) return String(value);
       const pad = (n: number) => String(n).padStart(2, "0");
       if (this.type === "date") return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
-      if (this.type === "time") return `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
-      return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}`;
+      return `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
     }
 
     private _setValue(input: { checked?: boolean; value: string | null }) {

--- a/src/mixins/form-field.ts
+++ b/src/mixins/form-field.ts
@@ -6,6 +6,19 @@ import { type AbstractConstructor } from "./utils.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { live } from "lit/directives/live.js";
 
+// Converts attribute strings to numbers when possible, preserving strings (e.g. date values) otherwise.
+const minMaxConverter = {
+  fromAttribute(value: string | null): string | number | undefined {
+    if (value === null || value === "") return undefined;
+    const num = Number(value);
+    return isNaN(num) ? value : num;
+  },
+  toAttribute(value: string | number | undefined): string | null {
+    if (value === undefined) return null;
+    return String(value);
+  }
+};
+
 // Retrieved on 2026/04/10 from https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input
 type GenericInputTypes =
   | "checkbox"
@@ -49,8 +62,8 @@ declare abstract class FormFieldInterface {
   input: HTMLInputElement;
   internals: ElementInternals;
   placeholder: string;
-  min: number;
-  max: number;
+  min: string | number;
+  max: string | number;
   readOnly?: boolean;
   abstract handleChange(event: Event): void;
   handleInput(event: Event): void;
@@ -143,11 +156,17 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
     /** Placeholder text shown when value is empty. */
     @property({ type: String, reflect: true }) placeholder?: string;
 
-    /** The minimum value for number inputs */
-    @property({ type: Number, reflect: true }) min?: number;
+    /** The minimum value for number/date/time inputs.
+     *
+     * For date / time inputs, this can be a string in the format of the input type (e.g., "2024-01-01" for date) or a number representing epoch milliseconds.
+     */
+    @property({ converter: minMaxConverter, reflect: true }) min?: string | number;
 
-    /** The maximum value for number inputs */
-    @property({ type: Number, reflect: true }) max?: number;
+    /** The maximum value for number/date/time inputs.
+     *
+     * For date / time inputs, this can be a string in the format of the input type (e.g., "2024-12-31" for date) or a number representing epoch milliseconds.
+     */
+    @property({ converter: minMaxConverter, reflect: true }) max?: string | number;
 
     /** Placeholder text shown when value is empty. */
     @property({ type: Boolean, reflect: true }) readOnly?: boolean;
@@ -254,9 +273,9 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
     private _handleInteger(event: InputEvent) {
       const input = event.target as HTMLInputElement;
       const cursor = input.selectionStart ?? 0;
-
+      const min = this.min !== undefined ? Number(this.min) : undefined;
       // Remove leading minus if min >= 0
-      if (this.min !== undefined && this.min >= 0) {
+      if (min !== undefined && isFinite(min) && min >= 0) {
         input.value = input.value.replace(/^-/, "");
       }
       // Remove non-integer characters except leading minus
@@ -276,15 +295,30 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
     }
 
     private _handleIntegerMinMax(input: HTMLInputElement) {
-      // Clamp to min/max if needed
-      if (this.min !== undefined && Number(input.value) < this.min) {
-        input.value = String(this.min);
-        this.value = String(this.min);
+      const min = this.min !== undefined ? Number(this.min) : undefined;
+      const max = this.max !== undefined ? Number(this.max) : undefined;
+      // Clamp to min/max if needed; skip if coerced value is NaN (e.g. min/max is a date string)
+      if (min !== undefined && isFinite(min) && Number(input.value) < min) {
+        input.value = String(min);
+        this.value = String(min);
       }
-      if (this.max !== undefined && Number(input.value) > this.max) {
-        input.value = String(this.max);
-        this.value = String(this.max);
+      if (max !== undefined && isFinite(max) && Number(input.value) > max) {
+        input.value = String(max);
+        this.value = String(max);
       }
+    }
+
+    private _formatMinMax(value: string | number | undefined): string | undefined {
+      if (value === undefined) return undefined;
+      if (typeof value === "string") return value;
+      // Only interpret numeric values as epoch-ms timestamps for date-like types
+      if (this.type !== "date" && this.type !== "time" && this.type !== "month") return String(value);
+      const date = new Date(value);
+      if (isNaN(date.getTime())) return String(value);
+      const pad = (n: number) => String(n).padStart(2, "0");
+      if (this.type === "date") return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+      if (this.type === "time") return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+      return `${date.getFullYear()}-${pad(date.getMonth() + 1)}`;
     }
 
     private _setValue(input: { checked?: boolean; value: string | null }) {
@@ -442,8 +476,8 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
             @focus=${this.handleFocus}
             @blur=${this.handleBlur}
             class="contourable-target"
-            min=${ifDefined(this.min)}
-            max=${ifDefined(this.max)}
+            min=${ifDefined(this._formatMinMax(this.min))}
+            max=${ifDefined(this._formatMinMax(this.max))}
           />`;
         case "range-selector":
           return html`<input
@@ -494,8 +528,8 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
             @change=${this._handleChange}
             @focus=${this.handleFocus}
             @blur=${this.handleBlur}
-            min=${ifDefined(this.min)}
-            max=${ifDefined(this.max)}
+            min=${ifDefined(this._formatMinMax(this.min))}
+            max=${ifDefined(this._formatMinMax(this.max))}
           /> `;
         case "integer":
           return html`<input
@@ -515,8 +549,8 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
             @change=${this._handleChange}
             @focus=${this.handleFocus}
             @blur=${this.handleBlur}
-            min=${ifDefined(this.min)}
-            max=${ifDefined(this.max)}
+            min=${ifDefined(this._formatMinMax(this.min))}
+            max=${ifDefined(this._formatMinMax(this.max))}
           /> `;
         default:
           return html`<input
@@ -536,8 +570,8 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
             @change=${this._handleChange}
             @focus=${this.handleFocus}
             @blur=${this.handleBlur}
-            min=${ifDefined(this.min)}
-            max=${ifDefined(this.max)}
+            min=${ifDefined(this._formatMinMax(this.min))}
+            max=${ifDefined(this._formatMinMax(this.max))}
           /> `;
 
         /*

--- a/src/mixins/form-field.ts
+++ b/src/mixins/form-field.ts
@@ -62,8 +62,8 @@ declare abstract class FormFieldInterface {
   input: HTMLInputElement;
   internals: ElementInternals;
   placeholder: string;
-  min: string | number;
-  max: string | number;
+  min?: string | number;
+  max?: string | number;
   readOnly?: boolean;
   abstract handleChange(event: Event): void;
   handleInput(event: Event): void;
@@ -316,9 +316,9 @@ export const FormField = <T extends AbstractConstructor<LitElement>>(superClass:
       const date = new Date(value);
       if (isNaN(date.getTime())) return String(value);
       const pad = (n: number) => String(n).padStart(2, "0");
-      if (this.type === "date") return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-      if (this.type === "time") return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
-      return `${date.getFullYear()}-${pad(date.getMonth() + 1)}`;
+      if (this.type === "date") return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+      if (this.type === "time") return `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+      return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}`;
     }
 
     private _setValue(input: { checked?: boolean; value: string | null }) {

--- a/src/test/stepper-input/stepper-input.test.ts
+++ b/src/test/stepper-input/stepper-input.test.ts
@@ -64,7 +64,7 @@ describe("zeta-stepper-input", () => {
     });
     it("sets value to max value via input onchange", async () => {
       // prettier-ignore
-      const el = await fixture<ZetaStepperInput>(html` <zeta-stepper-input max=${5}></zeta-stepper-input>`);
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input max=${5}></zeta-stepper-input>`);
       el.value = "6";
       await el.updateComplete;
       el.dispatchEvent(new InputEvent("input", { bubbles: true, composed: true }));
@@ -83,6 +83,72 @@ describe("zeta-stepper-input", () => {
       el?.dispatchEvent(new ZetaStepperChangeEvent({ value: el.value }).toEvent());
       await el.updateComplete;
       assert.equal(el.value, "-4");
+    });
+
+    it("should coerce numeric string attribute min/max to numbers", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input min="5" max="10"></zeta-stepper-input>`);
+      assert.equal(el.min, 5);
+      assert.equal(el.max, 10);
+    });
+
+    it("should set min/max to undefined when attribute is absent", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input></zeta-stepper-input>`);
+      assert.isUndefined(el.min);
+      assert.isUndefined(el.max);
+    });
+
+    it("should not clamp value when min is a non-numeric string", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="2"></zeta-stepper-input>`);
+      el.min = "abc";
+      el.requestUpdate();
+      await el.updateComplete;
+      assert.equal(el.value, "2");
+    });
+
+    it("should not clamp value when max is a non-numeric string", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="99"></zeta-stepper-input>`);
+      el.max = "abc";
+      el.requestUpdate();
+      await el.updateComplete;
+      assert.equal(el.value, "99");
+    });
+
+    it("should not disable decrement button when min is a non-numeric string", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="0"></zeta-stepper-input>`);
+      el.min = "abc";
+      await el.updateComplete;
+      const decrementBtn = el.shadowRoot?.querySelector("zeta-icon-button");
+      assert.isFalse(decrementBtn?.disabled);
+    });
+
+    it("should not disable increment button when max is a non-numeric string", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="0"></zeta-stepper-input>`);
+      el.max = "abc";
+      await el.updateComplete;
+      const incrementBtn = el.shadowRoot?.querySelectorAll("zeta-icon-button")[1];
+      assert.isFalse(incrementBtn?.disabled);
+    });
+
+    it("should disable decrement button when value equals numeric min", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input min="0" value="0"></zeta-stepper-input>`);
+      await el.updateComplete;
+      const decrementBtn = el.shadowRoot?.querySelector("zeta-icon-button");
+      assert.isTrue(decrementBtn?.disabled);
+    });
+
+    it("should disable increment button when value equals numeric max", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input max="10" value="10"></zeta-stepper-input>`);
+      await el.updateComplete;
+      const incrementBtn = el.shadowRoot?.querySelectorAll("zeta-icon-button")[1];
+      assert.isTrue(incrementBtn?.disabled);
     });
   });
 
@@ -148,66 +214,6 @@ describe("zeta-stepper-input", () => {
       await el.updateComplete;
 
       assert.equal(el?.value, "-5", "Input value should be '-5'");
-    });
-  });
-
-  describe("Min/Max property conversion", () => {
-    it("should coerce numeric string attribute min/max to numbers", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input min="5" max="10"></zeta-stepper-input>`);
-      assert.equal(el.min, 5);
-      assert.equal(el.max, 10);
-    });
-
-    it("should set min/max to undefined when attribute is absent", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input></zeta-stepper-input>`);
-      assert.isUndefined(el.min);
-      assert.isUndefined(el.max);
-    });
-
-    it("should not clamp value when min is a non-numeric string", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="2"></zeta-stepper-input>`);
-      el.min = "abc" as unknown as number;
-      el.requestUpdate();
-      await el.updateComplete;
-      assert.equal(el.value, "2");
-    });
-
-    it("should not clamp value when max is a non-numeric string", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="99"></zeta-stepper-input>`);
-      el.max = "abc" as unknown as number;
-      el.requestUpdate();
-      await el.updateComplete;
-      assert.equal(el.value, "99");
-    });
-
-    it("should not disable decrement button when min is a non-numeric string", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="0"></zeta-stepper-input>`);
-      el.min = "abc" as unknown as number;
-      await el.updateComplete;
-      const decrementBtn = el.shadowRoot?.querySelector("zeta-icon-button");
-      assert.isFalse(decrementBtn?.disabled);
-    });
-
-    it("should not disable increment button when max is a non-numeric string", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="0"></zeta-stepper-input>`);
-      el.max = "abc" as unknown as number;
-      await el.updateComplete;
-      const incrementBtn = el.shadowRoot?.querySelectorAll("zeta-icon-button")[1];
-      assert.isFalse(incrementBtn?.disabled);
-    });
-
-    it("should disable decrement button when value equals numeric min", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input min="0" value="0"></zeta-stepper-input>`);
-      await el.updateComplete;
-      const decrementBtn = el.shadowRoot?.querySelector("zeta-icon-button");
-      assert.isTrue(decrementBtn?.disabled);
-    });
-
-    it("should disable increment button when value equals numeric max", async () => {
-      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input max="10" value="10"></zeta-stepper-input>`);
-      await el.updateComplete;
-      const incrementBtn = el.shadowRoot?.querySelectorAll("zeta-icon-button")[1];
-      assert.isTrue(incrementBtn?.disabled);
     });
   });
 

--- a/src/test/stepper-input/stepper-input.test.ts
+++ b/src/test/stepper-input/stepper-input.test.ts
@@ -151,6 +151,66 @@ describe("zeta-stepper-input", () => {
     });
   });
 
+  describe("Min/Max property conversion", () => {
+    it("should coerce numeric string attribute min/max to numbers", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input min="5" max="10"></zeta-stepper-input>`);
+      assert.equal(el.min, 5);
+      assert.equal(el.max, 10);
+    });
+
+    it("should set min/max to undefined when attribute is absent", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input></zeta-stepper-input>`);
+      assert.isUndefined(el.min);
+      assert.isUndefined(el.max);
+    });
+
+    it("should not clamp value when min is a non-numeric string", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="2"></zeta-stepper-input>`);
+      el.min = "abc" as unknown as number;
+      el.requestUpdate();
+      await el.updateComplete;
+      assert.equal(el.value, "2");
+    });
+
+    it("should not clamp value when max is a non-numeric string", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="99"></zeta-stepper-input>`);
+      el.max = "abc" as unknown as number;
+      el.requestUpdate();
+      await el.updateComplete;
+      assert.equal(el.value, "99");
+    });
+
+    it("should not disable decrement button when min is a non-numeric string", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="0"></zeta-stepper-input>`);
+      el.min = "abc" as unknown as number;
+      await el.updateComplete;
+      const decrementBtn = el.shadowRoot?.querySelector("zeta-icon-button");
+      assert.isFalse(decrementBtn?.disabled);
+    });
+
+    it("should not disable increment button when max is a non-numeric string", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input value="0"></zeta-stepper-input>`);
+      el.max = "abc" as unknown as number;
+      await el.updateComplete;
+      const incrementBtn = el.shadowRoot?.querySelectorAll("zeta-icon-button")[1];
+      assert.isFalse(incrementBtn?.disabled);
+    });
+
+    it("should disable decrement button when value equals numeric min", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input min="0" value="0"></zeta-stepper-input>`);
+      await el.updateComplete;
+      const decrementBtn = el.shadowRoot?.querySelector("zeta-icon-button");
+      assert.isTrue(decrementBtn?.disabled);
+    });
+
+    it("should disable increment button when value equals numeric max", async () => {
+      const el = await fixture<ZetaStepperInput>(html`<zeta-stepper-input max="10" value="10"></zeta-stepper-input>`);
+      await el.updateComplete;
+      const incrementBtn = el.shadowRoot?.querySelectorAll("zeta-icon-button")[1];
+      assert.isTrue(incrementBtn?.disabled);
+    });
+  });
+
   // describe("Golden", () => {});
 
   // describe("Performance", () => {});

--- a/src/test/text-input/setup.ts
+++ b/src/test/text-input/setup.ts
@@ -17,7 +17,7 @@ interface Props {
   errorText?: string;
   name?: string;
   value?: string;
-  type?: "text" | "date" | "textarea" | "password" | "time" | "number" | "integer" | "month";
+  type?: "text" | "date" | "textarea" | "password" | "time" | "number" | "integer";
   min?: string | number;
   max?: string | number;
   rows?: number;

--- a/src/test/text-input/setup.ts
+++ b/src/test/text-input/setup.ts
@@ -17,9 +17,9 @@ interface Props {
   errorText?: string;
   name?: string;
   value?: string;
-  type?: "text" | "date" | "textarea" | "password" | "time" | "number" | "integer";
-  min?: number;
-  max?: number;
+  type?: "text" | "date" | "textarea" | "password" | "time" | "number" | "integer" | "month";
+  min?: string | number;
+  max?: string | number;
   rows?: number;
   showClearButton?: boolean;
 }

--- a/src/test/text-input/text-input.test.ts
+++ b/src/test/text-input/text-input.test.ts
@@ -133,6 +133,98 @@ describe("zeta-text-input", () => {
       const clearButton = el.shadowRoot?.querySelector(".cancel-icon");
       assert.notExists(clearButton, "Clear button should not exist");
     });
+
+    it("should accept numeric min/max as numbers on integer type", async () => {
+      const el = await setup({ type: "integer", min: 5, max: 10 });
+      assert.equal(el.min, 5);
+      assert.equal(el.max, 10);
+    });
+
+    it("should coerce numeric string attribute min/max to numbers", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="integer" min="5" max="10"></zeta-text-input>`);
+      assert.equal(el.min, 5);
+      assert.equal(el.max, 10);
+    });
+
+    it("should preserve string min/max for date type", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="date" min="2024-01-01" max="2024-12-31"></zeta-text-input>`);
+      assert.equal(el.min, "2024-01-01");
+      assert.equal(el.max, "2024-12-31");
+    });
+
+    it("should set min/max to undefined when attribute is absent", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="integer"></zeta-text-input>`);
+      assert.isUndefined(el.min);
+      assert.isUndefined(el.max);
+    });
+
+    it("should pass numeric min/max as-is to input for number type", async () => {
+      const el = await setup({ type: "number", min: 1, max: 100 });
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "1");
+      assert.equal(input?.getAttribute("max"), "100");
+    });
+
+    it("should pass string min/max as-is to input for date type", async () => {
+      const el = await setup({ type: "date", min: "2024-01-01", max: "2024-12-31" });
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "2024-01-01");
+      assert.equal(input?.getAttribute("max"), "2024-12-31");
+    });
+
+    it("should format epoch timestamp as date string for date type", async () => {
+      // prettier-ignore
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="date"></zeta-text-input>`);
+      el.min = new Date("2024-06-15").getTime();
+      el.max = new Date("2024-12-31").getTime();
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "2024-06-15");
+      assert.equal(input?.getAttribute("max"), "2024-12-31");
+    });
+
+    it("should format epoch timestamp as time string for time type", async () => {
+      const epoch = Date.UTC(2024, 0, 1, 8, 30);
+      // prettier-ignore
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="time"></zeta-text-input>`);
+      el.min = epoch;
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "08:30");
+    });
+
+    it("should not format numeric min/max as timestamps for non-date types", async () => {
+      const el = await setup({ type: "number", min: 0, max: 100 });
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "0");
+      assert.equal(input?.getAttribute("max"), "100");
+    });
+
+    it("should not clamp integer input when min/max is a non-numeric string", async () => {
+      const el = await setup({ type: "integer", min: "abc" });
+
+      await MouseActions.click(el);
+      await KeyboardActions.type("5");
+      await MouseActions.clickOutside(el);
+
+      await expect(el.value).to.equal("5");
+    });
+
+    it("should not strip leading minus when integer min is a non-numeric string", async () => {
+      const el = await setup({ type: "integer", min: "abc" });
+
+      await MouseActions.click(el);
+      await KeyboardActions.type("-5");
+      await MouseActions.clickOutside(el);
+
+      await expect(el.value).to.equal("-5");
+    });
   });
 
   // describe("Dimensions", () => {});
@@ -382,7 +474,7 @@ describe("zeta-text-input", () => {
       await expect(el.value).to.equal("");
     });
 
-    /// Increment / Decrement tests
+    // Increment / Decrement tests
     it("should increment value when type is integer and no max set", async () => {
       const el = await setup({ type: "integer", value: "5" });
       el.increment();
@@ -483,104 +575,6 @@ describe("zeta-text-input", () => {
       el.decrement();
       await el.updateComplete;
       assert.isFalse(changed);
-    });
-  });
-
-  describe("Min/Max property conversion", () => {
-    it("should accept numeric min/max as numbers on integer type", async () => {
-      const el = await setup({ type: "integer", min: 5, max: 10 });
-      assert.equal(el.min, 5);
-      assert.equal(el.max, 10);
-    });
-
-    it("should coerce numeric string attribute min/max to numbers", async () => {
-      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="integer" min="5" max="10"></zeta-text-input>`);
-      assert.equal(el.min, 5);
-      assert.equal(el.max, 10);
-    });
-
-    it("should preserve string min/max for date type", async () => {
-      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="date" min="2024-01-01" max="2024-12-31"></zeta-text-input>`);
-      assert.equal(el.min, "2024-01-01");
-      assert.equal(el.max, "2024-12-31");
-    });
-
-    it("should set min/max to undefined when attribute is absent", async () => {
-      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="integer"></zeta-text-input>`);
-      assert.isUndefined(el.min);
-      assert.isUndefined(el.max);
-    });
-
-    it("should pass numeric min/max as-is to input for number type", async () => {
-      const el = await setup({ type: "number", min: 1, max: 100 });
-      await el.updateComplete;
-      const input = el.shadowRoot?.querySelector("input");
-      assert.equal(input?.getAttribute("min"), "1");
-      assert.equal(input?.getAttribute("max"), "100");
-    });
-
-    it("should pass string min/max as-is to input for date type", async () => {
-      const el = await setup({ type: "date", min: "2024-01-01", max: "2024-12-31" });
-      await el.updateComplete;
-      const input = el.shadowRoot?.querySelector("input");
-      assert.equal(input?.getAttribute("min"), "2024-01-01");
-      assert.equal(input?.getAttribute("max"), "2024-12-31");
-    });
-
-    it("should format epoch timestamp as date string for date type", async () => {
-      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="date"></zeta-text-input>`);
-      el.min = new Date("2024-06-15").getTime();
-      el.max = new Date("2024-12-31").getTime();
-      await el.updateComplete;
-      const input = el.shadowRoot?.querySelector("input");
-      assert.equal(input?.getAttribute("min"), "2024-06-15");
-      assert.equal(input?.getAttribute("max"), "2024-12-31");
-    });
-
-    it("should format epoch timestamp as time string for time type", async () => {
-      const epoch = Date.UTC(2024, 0, 1, 8, 30);
-      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="time"></zeta-text-input>`);
-      el.min = epoch;
-      await el.updateComplete;
-      const input = el.shadowRoot?.querySelector("input");
-      assert.equal(input?.getAttribute("min"), "08:30");
-    });
-
-    it("should format epoch timestamp as month string for month type", async () => {
-      const epoch = Date.UTC(2024, 5, 1);
-      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="month"></zeta-text-input>`);
-      el.min = epoch;
-      await el.updateComplete;
-      const input = el.shadowRoot?.querySelector("input");
-      assert.equal(input?.getAttribute("min"), "2024-06");
-    });
-
-    it("should not format numeric min/max as timestamps for non-date types", async () => {
-      const el = await setup({ type: "number", min: 0, max: 100 });
-      await el.updateComplete;
-      const input = el.shadowRoot?.querySelector("input");
-      assert.equal(input?.getAttribute("min"), "0");
-      assert.equal(input?.getAttribute("max"), "100");
-    });
-
-    it("should not clamp integer input when min/max is a non-numeric string", async () => {
-      const el = await setup({ type: "integer", min: "abc" as unknown as number });
-
-      await MouseActions.click(el);
-      await KeyboardActions.type("5");
-      await MouseActions.clickOutside(el);
-
-      await expect(el.value).to.equal("5");
-    });
-
-    it("should not strip leading minus when integer min is a non-numeric string", async () => {
-      const el = await setup({ type: "integer", min: "abc" as unknown as number });
-
-      await MouseActions.click(el);
-      await KeyboardActions.type("-5");
-      await MouseActions.clickOutside(el);
-
-      await expect(el.value).to.equal("-5");
     });
   });
 

--- a/src/test/text-input/text-input.test.ts
+++ b/src/test/text-input/text-input.test.ts
@@ -1,4 +1,4 @@
-import { expect, assert, oneEvent } from "@open-wc/testing";
+import { expect, assert, oneEvent, fixture, html } from "@open-wc/testing";
 import { setup } from "./setup.js";
 import type { ZetaIcon } from "../../components/icon/icon.js";
 import { ZetaTextInput } from "../../components/text-input/text-input.js";
@@ -380,6 +380,207 @@ describe("zeta-text-input", () => {
       clearButton?.dispatchEvent(new Event("click", { bubbles: true, composed: true }));
       await changeListener;
       await expect(el.value).to.equal("");
+    });
+
+    /// Increment / Decrement tests
+    it("should increment value when type is integer and no max set", async () => {
+      const el = await setup({ type: "integer", value: "5" });
+      el.increment();
+      await el.updateComplete;
+      assert.equal(el.value, "6");
+    });
+
+    it("should not increment value when type is integer and value equals numeric max", async () => {
+      const el = await setup({ type: "integer", value: "10", max: 10 });
+      el.increment();
+      await el.updateComplete;
+      assert.equal(el.value, "10");
+    });
+
+    it("should increment value when type is integer and value is below numeric max", async () => {
+      const el = await setup({ type: "integer", value: "9", max: 10 });
+      el.increment();
+      await el.updateComplete;
+      assert.equal(el.value, "10");
+    });
+
+    it("should not increment value when type is integer and value is above numeric max", async () => {
+      const el = await setup({ type: "integer", value: "11", max: 10 });
+      el.increment();
+      await el.updateComplete;
+      assert.equal(el.value, "11");
+    });
+
+    it("should decrement value when type is integer and no min set", async () => {
+      const el = await setup({ type: "integer", value: "5" });
+      el.decrement();
+      await el.updateComplete;
+      assert.equal(el.value, "4");
+    });
+
+    it("should not decrement value when type is integer and value equals numeric min", async () => {
+      const el = await setup({ type: "integer", value: "0", min: 0 });
+      el.decrement();
+      await el.updateComplete;
+      assert.equal(el.value, "0");
+    });
+
+    it("should decrement value when type is integer and value is above numeric min", async () => {
+      const el = await setup({ type: "integer", value: "1", min: 0 });
+      el.decrement();
+      await el.updateComplete;
+      assert.equal(el.value, "0");
+    });
+
+    it("should not decrement value when type is integer and value is below numeric min", async () => {
+      const el = await setup({ type: "integer", value: "-1", min: 0 });
+      el.decrement();
+      await el.updateComplete;
+      assert.equal(el.value, "-1");
+    });
+
+    it("should not increment when type is not integer", async () => {
+      const el = await setup({ type: "text", value: "5" });
+      el.increment();
+      await el.updateComplete;
+      assert.equal(el.value, "5");
+    });
+
+    it("should not decrement when type is not integer", async () => {
+      const el = await setup({ type: "text", value: "5" });
+      el.decrement();
+      await el.updateComplete;
+      assert.equal(el.value, "5");
+    });
+
+    it("should dispatch change event when incrementing", async () => {
+      const el = await setup({ type: "integer", value: "5" });
+      const changeListener = oneEvent(el, "change");
+      el.increment();
+      await changeListener;
+    });
+
+    it("should dispatch change event when decrementing", async () => {
+      const el = await setup({ type: "integer", value: "5" });
+      const changeListener = oneEvent(el, "change");
+      el.decrement();
+      await changeListener;
+    });
+
+    it("should not dispatch change event when increment is blocked by max", async () => {
+      const el = await setup({ type: "integer", value: "10", max: 10 });
+      let changed = false;
+      el.addEventListener("change", () => (changed = true));
+      el.increment();
+      await el.updateComplete;
+      assert.isFalse(changed);
+    });
+
+    it("should not dispatch change event when decrement is blocked by min", async () => {
+      const el = await setup({ type: "integer", value: "0", min: 0 });
+      let changed = false;
+      el.addEventListener("change", () => (changed = true));
+      el.decrement();
+      await el.updateComplete;
+      assert.isFalse(changed);
+    });
+  });
+
+  describe("Min/Max property conversion", () => {
+    it("should accept numeric min/max as numbers on integer type", async () => {
+      const el = await setup({ type: "integer", min: 5, max: 10 });
+      assert.equal(el.min, 5);
+      assert.equal(el.max, 10);
+    });
+
+    it("should coerce numeric string attribute min/max to numbers", async () => {
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="integer" min="5" max="10"></zeta-text-input>`);
+      assert.equal(el.min, 5);
+      assert.equal(el.max, 10);
+    });
+
+    it("should preserve string min/max for date type", async () => {
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="date" min="2024-01-01" max="2024-12-31"></zeta-text-input>`);
+      assert.equal(el.min, "2024-01-01");
+      assert.equal(el.max, "2024-12-31");
+    });
+
+    it("should set min/max to undefined when attribute is absent", async () => {
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="integer"></zeta-text-input>`);
+      assert.isUndefined(el.min);
+      assert.isUndefined(el.max);
+    });
+
+    it("should pass numeric min/max as-is to input for number type", async () => {
+      const el = await setup({ type: "number", min: 1, max: 100 });
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "1");
+      assert.equal(input?.getAttribute("max"), "100");
+    });
+
+    it("should pass string min/max as-is to input for date type", async () => {
+      const el = await setup({ type: "date", min: "2024-01-01", max: "2024-12-31" });
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "2024-01-01");
+      assert.equal(input?.getAttribute("max"), "2024-12-31");
+    });
+
+    it("should format epoch timestamp as date string for date type", async () => {
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="date"></zeta-text-input>`);
+      el.min = new Date("2024-06-15").getTime();
+      el.max = new Date("2024-12-31").getTime();
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "2024-06-15");
+      assert.equal(input?.getAttribute("max"), "2024-12-31");
+    });
+
+    it("should format epoch timestamp as time string for time type", async () => {
+      const epoch = Date.UTC(2024, 0, 1, 8, 30);
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="time"></zeta-text-input>`);
+      el.min = epoch;
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "08:30");
+    });
+
+    it("should format epoch timestamp as month string for month type", async () => {
+      const epoch = Date.UTC(2024, 5, 1);
+      const el = await fixture<ZetaTextInput>(html`<zeta-text-input type="month"></zeta-text-input>`);
+      el.min = epoch;
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "2024-06");
+    });
+
+    it("should not format numeric min/max as timestamps for non-date types", async () => {
+      const el = await setup({ type: "number", min: 0, max: 100 });
+      await el.updateComplete;
+      const input = el.shadowRoot?.querySelector("input");
+      assert.equal(input?.getAttribute("min"), "0");
+      assert.equal(input?.getAttribute("max"), "100");
+    });
+
+    it("should not clamp integer input when min/max is a non-numeric string", async () => {
+      const el = await setup({ type: "integer", min: "abc" as unknown as number });
+
+      await MouseActions.click(el);
+      await KeyboardActions.type("5");
+      await MouseActions.clickOutside(el);
+
+      await expect(el.value).to.equal("5");
+    });
+
+    it("should not strip leading minus when integer min is a non-numeric string", async () => {
+      const el = await setup({ type: "integer", min: "abc" as unknown as number });
+
+      await MouseActions.click(el);
+      await KeyboardActions.type("-5");
+      await MouseActions.clickOutside(el);
+
+      await expect(el.value).to.equal("-5");
     });
   });
 


### PR DESCRIPTION
The Min / Max props on text input support numbers presently. Whilst this is a nice-to-have, this means that default html behaviour that uses strings can not also be used. This PR fixes this by allowing strings, which are parsed by the underlying input field, and adding functions for if numbers are pased 