### PR TITLE
feat(UX-1579): Add close event to ZetaSnackbar

### DIFF
--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -30,6 +30,13 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
   @property({ type: Boolean }) hasCloseAction: boolean = false;
 
   /**
+   * Function to call when the close button is clicked.
+   * @type {Function}
+   * @default () => {}
+   */
+  @property() onClose?: () => void;
+
+  /**
    * Label of the action.
    */
   @property({ type: String }) actionLabel?: string;
@@ -56,15 +63,14 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
         </div>
         <div>
           ${this.actionLabel && this.actionClick ? html` <button id="action" @click=${this.actionClick}>${this.actionLabel}</button> ` : nothing}
-          ${
-            this.hasCloseAction
-              ? html`
-                  <button id="closeButton" @click=${() => this.remove()}>
+          ${this.hasCloseAction
+        ? html`
+                  <button id="closeButton" @click=${this.onClose ? this.onClose : () => this.remove()}>
                     <zeta-icon id="closeIcon" .rounded=${this.shape !== "sharp"}>${this.closeActionIcon ?? "cancel"}</zeta-icon>
                   </button>
                 `
-              : nothing
-          }
+        : nothing
+      }
         </div>
       </div>
     `;

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -66,7 +66,7 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
           ${
             this.hasCloseAction
               ? html`
-                  <button id="closeButton" @click=${this._onClose}>
+                  <button id="closeButton" @click=${this._onClose.bind(this)}>
                     <zeta-icon id="closeIcon" .rounded=${this.shape !== "sharp"}>${this.closeActionIcon ?? "cancel"}</zeta-icon>
                   </button>
                 `

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -30,11 +30,10 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
   @property({ type: Boolean }) hasCloseAction: boolean = false;
 
   /**
-   * Function to call when the close button is clicked.
+   * Optional function to call when the close button is clicked.
    * @type {Function}
-   * @default () => {}
    */
-  @property() onClose?: () => void;
+  @property({attribute: false}) onClose?: () => void;
 
   /**
    * Label of the action.

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -63,14 +63,15 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
         </div>
         <div>
           ${this.actionLabel && this.actionClick ? html` <button id="action" @click=${this.actionClick}>${this.actionLabel}</button> ` : nothing}
-          ${this.hasCloseAction
-        ? html`
+          ${
+            this.hasCloseAction
+              ? html`
                   <button id="closeButton" @click=${this.onClose ? this.onClose : () => this.remove()}>
                     <zeta-icon id="closeIcon" .rounded=${this.shape !== "sharp"}>${this.closeActionIcon ?? "cancel"}</zeta-icon>
                   </button>
                 `
-        : nothing
-      }
+              : nothing
+          }
         </div>
       </div>
     `;

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -13,9 +13,9 @@ import { type ZetaIconName } from "@zebra-fed/zeta-icons";
  *
  * @slot - The text of the snackbar.
  * @slot icon - The icon of the snackbar.
- * 
+ *
  * @event {Event} close - Fired when the snackbar is closed.
- * 
+ *
  * @figma https://www.figma.com/design/JesXQFLaPJLc1BdBM4sisI/%F0%9F%A6%93-ZDS---Components?node-id=229-13&node-type=canvas&m=dev
  * @storybook https://design.zebra.com/web/storybook/index.html?path=/docs/components-snackbar--docs
  */
@@ -49,10 +49,10 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
    */
   @property() actionClick?: () => void;
 
-    _onClose() {
-      this.dispatchEvent(new Event("close"));
-      this.remove()
-    }
+  _onClose() {
+    this.dispatchEvent(new Event("close"));
+    this.remove();
+  }
 
   render() {
     return html`
@@ -66,7 +66,7 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
           ${
             this.hasCloseAction
               ? html`
-                  <button id="closeButton"  @click=${this._onClose}>
+                  <button id="closeButton" @click=${this._onClose}>
                     <zeta-icon id="closeIcon" .rounded=${this.shape !== "sharp"}>${this.closeActionIcon ?? "cancel"}</zeta-icon>
                   </button>
                 `

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -13,7 +13,9 @@ import { type ZetaIconName } from "@zebra-fed/zeta-icons";
  *
  * @slot - The text of the snackbar.
  * @slot icon - The icon of the snackbar.
- *
+ * 
+ * @event {Event} close - Fired when the snackbar is closed.
+ * 
  * @figma https://www.figma.com/design/JesXQFLaPJLc1BdBM4sisI/%F0%9F%A6%93-ZDS---Components?node-id=229-13&node-type=canvas&m=dev
  * @storybook https://design.zebra.com/web/storybook/index.html?path=/docs/components-snackbar--docs
  */
@@ -28,12 +30,6 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
    * Whether the snackbar has a close action.
    */
   @property({ type: Boolean }) hasCloseAction: boolean = false;
-
-  /**
-   * Optional function to call when the close button is clicked.
-   * @type {Function}
-   */
-  @property({ attribute: false }) onClose?: () => void;
 
   /**
    * Label of the action.
@@ -53,6 +49,11 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
    */
   @property() actionClick?: () => void;
 
+    _onClose() {
+      this.dispatchEvent(new Event("close"));
+      this.remove()
+    }
+
   render() {
     return html`
       <div class="snackbar-root contourable-target">
@@ -65,7 +66,7 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
           ${
             this.hasCloseAction
               ? html`
-                  <button id="closeButton" @click=${this.onClose ? this.onClose : () => this.remove()}>
+                  <button id="closeButton"  @click=${this._onClose}>
                     <zeta-icon id="closeIcon" .rounded=${this.shape !== "sharp"}>${this.closeActionIcon ?? "cancel"}</zeta-icon>
                   </button>
                 `

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -33,7 +33,7 @@ export class ZetaSnackbar extends ContourableThree(Interactive(LitElement)) {
    * Optional function to call when the close button is clicked.
    * @type {Function}
    */
-  @property({attribute: false}) onClose?: () => void;
+  @property({ attribute: false }) onClose?: () => void;
 
   /**
    * Label of the action.

--- a/src/stories/components/Snackbar/snackbar.stories.ts
+++ b/src/stories/components/Snackbar/snackbar.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
+import { fn } from "@storybook/test";
 import { html } from "lit";
 import "../../../components/icon/icon.js";
 import { ZetaSnackbar } from "../../../components/snackbar/snackbar.js";
@@ -19,7 +20,8 @@ const meta: Meta<ZetaSnackbar & { slotIcon: string }> = {
     hasCloseAction: true,
     actionLabel: "Action",
     status: "default",
-    actionClick: () => console.log("Action Clicked")
+    actionClick: fn(),
+    onclose: fn()
   },
   parameters: {
     design: {
@@ -59,7 +61,7 @@ export default meta;
 // canvas code block does not show props in snippit.
 export const Snackbar: StoryObj<ZetaSnackbar | any> = {
   render: args => html`
-    <zeta-snackbar ${spread(args)} .actionClick=${() => console.log("Action Clicked")}>
+    <zeta-snackbar ${spread(args)} .actionClick=${args.actionClick}>
       <zeta-icon slot="icon">${args.slotIcon}</zeta-icon>
       ${args.slot}
     </zeta-snackbar>

--- a/src/test/snackbar/snackbar.test.ts
+++ b/src/test/snackbar/snackbar.test.ts
@@ -322,7 +322,6 @@ describe("zeta-snackbar", () => {
       const snackbar = document.querySelector("zeta-snackbar");
       expect(snackbar).to.exist;
     });
-
   });
 
   // describe("Golden", () => {});

--- a/src/test/snackbar/snackbar.test.ts
+++ b/src/test/snackbar/snackbar.test.ts
@@ -270,57 +270,54 @@ describe("zeta-snackbar", () => {
       await waitUntil(() => clicked, "Button Action fired", { timeout: 100 });
     });
 
-    it("calls the onClose function on mouse click and does not remove the element", async () => {
+    it("dispatches the close event on mouse click and removes the element", async () => {
       let closed = false;
 
-      subject.onClose = () => {
+      subject.addEventListener("close", () => {
         closed = true;
-      };
-      await subject.updateComplete;
+      });
 
       const closeIcon = subject.shadowRoot!.querySelector("#closeIcon") as ZetaIcon;
       await MouseActions.click(closeIcon, "left");
 
-      await waitUntil(() => closed, "onClose should be called", { timeout: 100 });
+      await waitUntil(() => closed, "close event should be dispatched", { timeout: 100 });
 
       const snackbar = document.querySelector("zeta-snackbar");
-      expect(snackbar).to.exist;
+      expect(snackbar).to.not.exist;
     });
 
-    it("calls the onClose function on enter pressed and does not remove the element", async () => {
+    it("dispatches the close event on enter pressed and removes the element", async () => {
       let closed = false;
 
-      subject.onClose = () => {
+      subject.addEventListener("close", () => {
         closed = true;
-      };
-      await subject.updateComplete;
+      });
 
       await sendKeys({ press: "Tab" });
       await sendKeys({ press: "Tab" });
       await sendKeys({ press: "Enter" });
 
-      await waitUntil(() => closed, "onClose should be called on Enter", { timeout: 200 });
+      await waitUntil(() => closed, "close event should be dispatched on Enter", { timeout: 200 });
 
       const snackbar = document.querySelector("zeta-snackbar");
-      expect(snackbar).to.exist;
+      expect(snackbar).to.not.exist;
     });
 
-    it("calls the onClose function on space pressed and does not remove the element", async () => {
+    it("dispatches the close event on space pressed and removes the element", async () => {
       let closed = false;
 
-      subject.onClose = () => {
+      subject.addEventListener("close", () => {
         closed = true;
-      };
-      await subject.updateComplete;
+      });
 
       await sendKeys({ press: "Tab" });
       await sendKeys({ press: "Tab" });
       await sendKeys({ press: " " });
 
-      await waitUntil(() => closed, "onClose should be called on Space", { timeout: 200 });
+      await waitUntil(() => closed, "close event should be dispatched on Space", { timeout: 200 });
 
       const snackbar = document.querySelector("zeta-snackbar");
-      expect(snackbar).to.exist;
+      expect(snackbar).to.not.exist;
     });
   });
 

--- a/src/test/snackbar/snackbar.test.ts
+++ b/src/test/snackbar/snackbar.test.ts
@@ -269,6 +269,60 @@ describe("zeta-snackbar", () => {
       await MouseActions.click(subject.shadowRoot!.querySelector("#action") as HTMLElement, "left");
       await waitUntil(() => clicked, "Button Action fired", { timeout: 100 });
     });
+
+    it("calls the onClose function on mouse click and does not remove the element", async () => {
+      let closed = false;
+
+      subject.onClose = () => {
+        closed = true;
+      };
+      await subject.updateComplete;
+
+      const closeIcon = subject.shadowRoot!.querySelector("#closeIcon") as ZetaIcon;
+      await MouseActions.click(closeIcon, "left");
+
+      await waitUntil(() => closed, "onClose should be called", { timeout: 100 });
+
+      const snackbar = document.querySelector("zeta-snackbar");
+      expect(snackbar).to.exist;
+    });
+
+    it("calls the onClose function on enter pressed and does not remove the element", async () => {
+      let closed = false;
+
+      subject.onClose = () => {
+        closed = true;
+      };
+      await subject.updateComplete;
+
+      await sendKeys({ press: "Tab" });
+      await sendKeys({ press: "Tab" });
+      await sendKeys({ press: "Enter" });
+
+      await waitUntil(() => closed, "onClose should be called on Enter", { timeout: 200 });
+
+      const snackbar = document.querySelector("zeta-snackbar");
+      expect(snackbar).to.exist;
+    });
+
+    it("calls the onClose function on space pressed and does not remove the element", async () => {
+      let closed = false;
+
+      subject.onClose = () => {
+        closed = true;
+      };
+      await subject.updateComplete;
+
+      await sendKeys({ press: "Tab" });
+      await sendKeys({ press: "Tab" });
+      await sendKeys({ press: " " });
+
+      await waitUntil(() => closed, "onClose should be called on Space", { timeout: 200 });
+
+      const snackbar = document.querySelector("zeta-snackbar");
+      expect(snackbar).to.exist;
+    });
+
   });
 
   // describe("Golden", () => {});


### PR DESCRIPTION
- Updated ZetaSnackbar to fire close event when the snackbar is closed
- Documentation is updated with the close event
- Tests updated